### PR TITLE
Add studio carousel section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1622,3 +1622,95 @@ header {
         max-width: 100%;
     }
 }
+
+/* Studio Carousel Section */
+.studio-carousel-section {
+    background: var(--card-bg);
+    padding: 60px 0;
+    text-align: center;
+}
+
+.studio-carousel {
+    position: relative;
+    max-width: 1000px;
+    margin: 0 auto;
+    overflow: hidden;
+}
+
+.studio-carousel .slides {
+    display: flex;
+}
+
+.studio-carousel .slides img {
+    width: 100%;
+    flex-shrink: 0;
+    display: none;
+    max-height: 550px;
+    object-fit: cover;
+    cursor: pointer;
+}
+
+.studio-carousel .slides img.active {
+    display: block;
+}
+
+.carousel-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.5);
+    border: none;
+    color: #fff;
+    font-size: 2rem;
+    padding: 10px 15px;
+    cursor: pointer;
+    z-index: 2;
+}
+
+.carousel-btn.prev { left: 15px; }
+.carousel-btn.next { right: 15px; }
+
+.carousel-btn:hover {
+    background: rgba(0, 0, 0, 0.8);
+}
+
+.studio-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.studio-modal.open {
+    visibility: visible;
+    opacity: 1;
+}
+
+.studio-modal img {
+    max-width: 90%;
+    max-height: 90%;
+}
+
+.studio-modal .close {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    color: #fff;
+    font-size: 2rem;
+    cursor: pointer;
+}
+
+@media (max-width: 768px) {
+    .carousel-btn {
+        font-size: 1.5rem;
+        padding: 8px 12px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -376,6 +376,34 @@
     });
 </script>
 
+<section id="studio" class="section studio-carousel-section">
+    <div class="container">
+        <h2 class="section-title">Our New Studio</h2>
+        <div class="studio-carousel">
+            <button class="carousel-btn prev" aria-label="Previous slide">&#10094;</button>
+            <div class="slides">
+                <img src="assets/images/studio/DSC00482.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00488.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00496.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00498.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00501.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00502.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00517.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00520.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00522.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00530.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00539.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00541.webp" alt="Sweet Dreams Studio interior" />
+                <img src="assets/images/studio/DSC00545.webp" alt="Sweet Dreams Studio interior" />
+            </div>
+            <button class="carousel-btn next" aria-label="Next slide">&#10095;</button>
+        </div>
+    </div>
+    <div class="studio-modal">
+        <span class="close">&times;</span>
+        <img src="" alt="Expanded studio view" />
+    </div>
+</section>
 
 <section id="giveaway" class="section giveaway-section">
     <div class="container">

--- a/js/main.js
+++ b/js/main.js
@@ -102,3 +102,66 @@ window.addEventListener('scroll', () => {
         }
     });
 });
+
+// Studio Carousel Logic
+document.addEventListener('DOMContentLoaded', () => {
+    const slides = document.querySelectorAll('.studio-carousel .slides img');
+    if (!slides.length) return;
+
+    let currentIndex = 0;
+    const prevBtn = document.querySelector('.studio-carousel .prev');
+    const nextBtn = document.querySelector('.studio-carousel .next');
+
+    function showSlide(index) {
+        slides.forEach((img, i) => {
+            img.classList.toggle('active', i === index);
+        });
+    }
+
+    prevBtn.addEventListener('click', () => {
+        currentIndex = (currentIndex - 1 + slides.length) % slides.length;
+        showSlide(currentIndex);
+    });
+
+    nextBtn.addEventListener('click', () => {
+        currentIndex = (currentIndex + 1) % slides.length;
+        showSlide(currentIndex);
+    });
+
+    showSlide(currentIndex);
+
+    // Swipe support
+    let startX = null;
+    slides.forEach(img => {
+        img.addEventListener('touchstart', e => startX = e.touches[0].clientX);
+        img.addEventListener('touchend', e => {
+            if (startX === null) return;
+            const endX = e.changedTouches[0].clientX;
+            if (startX - endX > 50) nextBtn.click();
+            else if (endX - startX > 50) prevBtn.click();
+            startX = null;
+        });
+    });
+
+    // Fullscreen modal
+    const modal = document.querySelector('.studio-modal');
+    const modalImg = modal.querySelector('img');
+    const modalClose = modal.querySelector('.close');
+
+    slides.forEach(img => {
+        img.addEventListener('click', () => {
+            modal.classList.add('open');
+            modalImg.src = img.src;
+        });
+    });
+
+    modalClose.addEventListener('click', () => {
+        modal.classList.remove('open');
+    });
+
+    modal.addEventListener('click', e => {
+        if (e.target === modal) {
+            modal.classList.remove('open');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- showcase the new studio in a photo carousel
- style the carousel with new CSS rules
- implement JavaScript for navigation, touch swipe and fullscreen viewing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_684a15562bb88329ae507075d26fee0c